### PR TITLE
Fix duplicate error messages #142

### DIFF
--- a/src/runScript.js
+++ b/src/runScript.js
@@ -61,11 +61,12 @@ module.exports = function runScript(commands, pathsToLint, config) {
           const errStderr = errors.map(err => err.stderr).join('')
 
           // prettier-ignore
-          throw new Error(dedent`
+          console.log(dedent`
               ${logSymbols.error} ${linter} found some errors. Please fix them and try committing again.
               ${errStdout}
               ${errStderr}
             `)
+          throw new Error('');
         })
     }
   }))


### PR DESCRIPTION
Instead of throwing the error to the error method, we log it and pass an empty string to it.